### PR TITLE
fix: Kubelet identity needed Managed Identity Operator over cert mgr identity

### DIFF
--- a/foundation/shared-services/core/managed-identity.tf
+++ b/foundation/shared-services/core/managed-identity.tf
@@ -54,3 +54,9 @@ resource "azurerm_role_assignment" "aks_managed_identity_operator" {
   role_definition_name = "Managed Identity Operator"
   principal_id         = module.aks.kubelet_identity_object_id
 }
+
+resource "azurerm_role_assignment" "aks_managed_identity_operator_for_cert_manager_identity" {
+  scope                = azurerm_user_assigned_identity.cert_manager_pod_identity.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = module.aks.kubelet_identity_object_id
+}


### PR DESCRIPTION
Since the cert manager's managed identity is not created in the kubelet's namespace, the kubelet identity didn't have the `Managed Identity Operator` access it needed to assign the managed identity to the cert manager controller