### PR TITLE
feat(security): ENG-2246 add ability to create a disk encryption set

### DIFF
--- a/modules/azure/key-vault/main.tf
+++ b/modules/azure/key-vault/main.tf
@@ -55,3 +55,18 @@ resource "azurerm_key_vault_key" "generated" {
   key_size     = each.value.key_size
   key_opts     = each.value.key_opts
 }
+
+resource "azurerm_disk_encryption_set" "generated" {
+  for_each = {
+    for k, v in var.vault_keys : k => v
+    if v.used_for_disk_encryption == true
+  }
+  name                = each.value.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  key_vault_key_id    = azurerm_key_vault_key.generated[each.key].id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}


### PR DESCRIPTION
Generated keys in the vault now have an extra value in the map named
`used_for_disk_encryption`. When this value is true the key will be used
to create a disk encryption set allowing things like AKS to have
encrypted data at rest.