### PR TITLE
feat(security): ENG-2227 add key-gen module and add disk encryption for ask

### DIFF
--- a/examples/terragrunt/3-landing-zones/core/terragrunt.hcl
+++ b/examples/terragrunt/3-landing-zones/core/terragrunt.hcl
@@ -33,13 +33,11 @@ inputs = {
   ms_defender_enabled_resources = {
     "Containers" = false
   }
-  vault_keys =  {
-    mykey = {
-      name                        = "mykey"
-      used_for_disk_encryption    = true
-      # Key type defaulted to EC - select elliptical curve strength below
-      curve                       = "P-384"
-    }
+  vault_key_to_create =  {
+    name                        = "mykey"
+    used_for_disk_encryption    = true
+    # Key type defaulted to EC - select elliptical curve strength below
+    curve                       = "P-384"
   }
 }
 

--- a/landing-zones/aks/core/variables.tf
+++ b/landing-zones/aks/core/variables.tf
@@ -131,6 +131,6 @@ variable "aks_disk_encryption_key_name" {
 
 variable "aks_enable_disk_encryption" {
   type        = bool
-  description = "Wether or not to enable disk encryption in the AKS Cluster"
+  description = "Whether or not to enable disk encryption in the AKS Cluster"
   default     = true
 }

--- a/landing-zones/aks/core/variables.tf
+++ b/landing-zones/aks/core/variables.tf
@@ -111,8 +111,8 @@ variable "enabled_for_disk_encryption" {
   default     = true
 }
 
-variable "vault_keys" {
-  description = "A map of keys to generate in the Azure Key Vault"
+variable "vault_key_to_create" {
+  description = "A map with a key to generate in the Azure Key Vault"
   type        = map(any)
   default     = {}
 }
@@ -121,4 +121,16 @@ variable "log_analytics_workspace_id" {
   description = "Log analytics workspace ID. If none is supplied, local will default to sourcing from CAF management"
   type        = string
   default     = ""
+}
+
+variable "aks_disk_encryption_key_name" {
+  type        = string
+  description = "The key name to use for disk encryption created in the Azure Key Vault"
+  default     = null
+}
+
+variable "aks_enable_disk_encryption" {
+  type        = bool
+  description = "Wether or not to enable disk encryption in the AKS Cluster"
+  default     = true
 }

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -16,6 +16,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   location                = var.location
   resource_group_name     = var.lz_resource_group
   dns_prefix              = var.name
+  disk_encryption_set_id  = var.disk_encryption_set_id != null ? var.disk_encryption_set_id : null
   private_dns_zone_id     = var.private_dns_zone_id
   private_cluster_enabled = true
   kubernetes_version      = var.kubernetes_version
@@ -86,3 +87,4 @@ resource "azurerm_kubernetes_cluster" "aks" {
 data "azurerm_resource_group" "aks_node_pool_resource_group" {
   name = azurerm_kubernetes_cluster.aks.node_resource_group
 }
+

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   location                = var.location
   resource_group_name     = var.lz_resource_group
   dns_prefix              = var.name
-  disk_encryption_set_id  = var.disk_encryption_set_id != null ? var.disk_encryption_set_id : null
+  disk_encryption_set_id  = var.aks_enable_disk_encryption ? var.disk_encryption_set_id : null
   private_dns_zone_id     = var.private_dns_zone_id
   private_cluster_enabled = true
   kubernetes_version      = var.kubernetes_version

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -94,7 +94,7 @@ variable "aks_disk_encryption_key_name" {
 
 variable "aks_enable_disk_encryption" {
   type        = bool
-  description = "Wether or not to enable disk encryption in the AKS Cluster"
+  description = "Whether or not to enable disk encryption in the AKS Cluster"
   default     = true
 }
 

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -85,3 +85,22 @@ variable "enable_aks_policy_addon" {
   description = "Feature flag to enable AKS Policy Add On"
   default     = false
 }
+
+variable "aks_disk_encryption_key_name" {
+  type        = string
+  description = "The key name to use for disk encryption created in the Azure Key Vault"
+  default     = null
+}
+
+variable "aks_enable_disk_encryption" {
+  type        = bool
+  description = "Wether or not to enable disk encryption in the AKS Cluster"
+  default     = true
+}
+
+variable "disk_encryption_set_id" {
+  type        = string
+  description = "The disk encryption set ID"
+  default     = null
+
+}

--- a/modules/azure/key-gen/main.tf
+++ b/modules/azure/key-gen/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.96.0"
+      configuration_aliases = [
+        azurerm.connectivity
+      ]
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault_key" "key" {
+  count = var.vault_key_to_create != null ? 1 : 0
+
+  name         = var.vault_key_to_create.name
+  key_vault_id = var.key_vault_id
+
+  # Defaulting to EC key type as elliptical curve encryption is more secure
+  # than RSA and has no mathematical means of breaking the encryption.
+  key_type        = "EC"
+  curve           = can(var.vault_key_to_create.curve) ? var.vault_key_to_create.curve : "P-384"
+  expiration_date = can(var.vault_key_to_create.expiration_date) ? var.vault_key_to_create.expiration_date : formatdate("Y-m-d'T'H:M:S'Z'", timeadd(timestamp(), "8760h"))
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_disk_encryption_set" "encryption_set" {
+  count = var.vault_key_to_create != null ? 1 : 0
+
+  name                      = var.vault_key_to_create.name
+  auto_key_rotation_enabled = true
+  resource_group_name       = var.resource_group_name
+  location                  = var.location
+  key_vault_key_id          = azurerm_key_vault_key.key[0].id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/modules/azure/key-gen/main.tf
+++ b/modules/azure/key-gen/main.tf
@@ -13,7 +13,7 @@ terraform {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault_key" "key" {
-  count = var.vault_key_to_create != null ? 1 : 0
+  count = var.vault_key_to_create != {} ? 1 : 0
 
   name         = var.vault_key_to_create.name
   key_vault_id = var.key_vault_id
@@ -34,7 +34,7 @@ resource "azurerm_key_vault_key" "key" {
 }
 
 resource "azurerm_disk_encryption_set" "encryption_set" {
-  count = var.vault_key_to_create != null ? 1 : 0
+  count = var.vault_key_to_create != {} ? 1 : 0
 
   name                      = var.vault_key_to_create.name
   auto_key_rotation_enabled = true

--- a/modules/azure/key-gen/outputs.tf
+++ b/modules/azure/key-gen/outputs.tf
@@ -1,0 +1,3 @@
+output "disk_encryption_set_id" {
+  value = azurerm_disk_encryption_set.encryption_set[0].id
+}

--- a/modules/azure/key-gen/variables.tf
+++ b/modules/azure/key-gen/variables.tf
@@ -1,15 +1,5 @@
-variable "environment" {
-  description = "The env dev, qa, prod that the key vault is in"
-  type        = string
-}
-
 variable "location" {
   description = "The Azure Region in which all resources should be provisioned"
-  type        = string
-}
-
-variable "name" {
-  description = "Unique resources name"
   type        = string
 }
 
@@ -24,22 +14,19 @@ variable "tags" {
   default     = {}
 }
 
-variable "workload" {
-  description = "workload/application this key vault is being deployed for"
-  type        = string
-}
-
-variable "service_endpoints_subnet_id" {
-  description = "Subnet ID in which to place Key Vault private endpoint"
-  type        = string
-}
-
-variable "connectivity_resource_group_name" {
-  type = string
-}
-
 variable "enabled_for_disk_encryption" {
   description = "Whether or not to allow the Azure Disk Encryption to retrieve certs stored in key vault"
   type        = bool
   default     = true
+}
+
+variable "vault_key_to_create" {
+  description = "A map with a key to generate in the Azure Key Vault"
+  type        = map(any)
+  default     = {}
+}
+
+variable "key_vault_id" {
+  description = "The key vault ID to store the generated keys in."
+  type        = string
 }


### PR DESCRIPTION

Adds the ability to enable disk encryption to an AKS cluster by
providing a `disk_encryption_set_id` to the AKS module. This is provided
by the new `key-gen` module which creates a key in a key vault. It will
aditionally create an encryption_set for the given key when the value is
enabled. This module was previously integrated into the `key-vault`
module but has now been separated out.