### PR TITLE
feat: FLY-29 update access policy permission defaults for key creation

### DIFF
--- a/modules/azure/key-vault/main.tf
+++ b/modules/azure/key-vault/main.tf
@@ -32,16 +32,42 @@ resource "azurerm_key_vault" "key_vault" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
 
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "List",
+      "Update",
+    ]
+
     key_permissions = [
       "Get",
+      "Create",
+      "Decrypt",
+      "Delete",
+      "Encrypt",
+      "List",
+      "Sign",
+      "UnwrapKey",
+      "Update",
+      "Verify",
+      "WrapKey",
     ]
 
     secret_permissions = [
       "Get",
+      "Delete",
+      "List",
+      "Set",
     ]
 
     storage_permissions = [
       "Get",
+      "Delete",
+      "List",
+      "RegenerateKey",
+      "Set",
+      "Update",
     ]
   }
 }


### PR DESCRIPTION
Update the defaults of the access policy for the key vault to provide a
basic, generalized set of default permissions. This should be a
minimally required set of permissions (further testing could surely
improve) for all applications to use. This should be overwritable in the
future.