### PR TITLE
feat(security): FLY-30 add ability to override access policy lists

### DIFF
--- a/examples/terragrunt/3-landing-zones/core/terragrunt.hcl
+++ b/examples/terragrunt/3-landing-zones/core/terragrunt.hcl
@@ -28,22 +28,30 @@ inputs = {
   external_app                          = true
   dns_zone_name                         = "your-sub.myzone.com"
   parent_dns_zone_name                  = "myzone.com"
-  enable_aks_policy_addon               = true
-  enable_ms_defender                    = false
+
+  # Security inputs
+  enable_aks_policy_addon = true
+  enable_ms_defender      = false
   ms_defender_enabled_resources = {
     "Containers" = false
   }
-  vault_key_to_create =  {
-    name                        = "mykey"
-    used_for_disk_encryption    = true
+  aks_enable_disk_encryption = true
+  vault_key_to_create = {
+    name                     = "mykey"
+    used_for_disk_encryption = true
     # Key type defaulted to EC - select elliptical curve strength below
-    curve                       = "P-384"
+    curve = "P-384"
   }
+  certificate_permission = ["Get", ]
+  key_permission         = ["Get", ]
+  secret_permission      = ["Get", ]
+  storage_permission     = ["Get", ]
+  application_id         = "yourappidforkeyvaultaccesspolicy"
 }
 
 # Use the latest stable release, see https://github.com/liatrio/terraform-caf-azure/releases
 terraform {
-  source = "git@github.com:liatrio/terraform-caf-azure//landing-zones/aks/core?ref=v0.33.0"
+  source = "git@github.com:liatrio/terraform-caf-azure//landing-zones/aks/core?ref=v0.35.0"
 }
 
 # Generate the provider.tf files

--- a/landing-zones/aks/core/main.tf
+++ b/landing-zones/aks/core/main.tf
@@ -43,6 +43,11 @@ module "key_vault" {
   service_endpoints_subnet_id      = module.aks_vnet.service_endpoints_subnet_id
   connectivity_resource_group_name = var.connectivity_resource_group_name
   enabled_for_disk_encryption      = var.enabled_for_disk_encryption
+  application_id                   = var.application_id
+  certificate_permissions          = var.certificate_permissions
+  key_permissions                  = var.key_permissions
+  secret_permissions               = var.secret_permissions
+  storage_permissions              = var.storage_permissions
 }
 
 module "key_gen" {

--- a/landing-zones/aks/core/variables.tf
+++ b/landing-zones/aks/core/variables.tf
@@ -128,3 +128,33 @@ variable "aks_enable_disk_encryption" {
   description = "Whether or not to enable disk encryption in the AKS Cluster"
   default     = true
 }
+
+variable "certificate_permissions" {
+  description = "A list of certificate permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "key_permissions" {
+  description = "A list of key permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "secret_permissions" {
+  description = "A list of secret permissions permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_permissions" {
+  description = "A list of storage permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "application_id" {
+  description = "The application ID to give to key vault when setting access policies"
+  type        = string
+  default     = null
+}

--- a/modules/azure/key-vault/main.tf
+++ b/modules/azure/key-vault/main.tf
@@ -29,19 +29,46 @@ resource "azurerm_key_vault" "key_vault" {
   sku_name = "standard"
 
   access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
+    tenant_id      = data.azurerm_client_config.current.tenant_id
+    object_id      = data.azurerm_client_config.current.object_id
+    application_id = var.application_id != null ? var.application_id : null
 
-    key_permissions = [
+    certificate_permissions = length(var.certificate_permissions) > 0 ? var.certificate_permissions : [
+      "Create",
+      "Delete",
       "Get",
+      "List",
+      "Update",
     ]
 
-    secret_permissions = [
+    key_permissions = length(var.key_permissions) > 0 ? var.key_permissions : [
       "Get",
+      "Create",
+      "Decrypt",
+      "Delete",
+      "Encrypt",
+      "List",
+      "Sign",
+      "UnwrapKey",
+      "Update",
+      "Verify",
+      "WrapKey",
     ]
 
-    storage_permissions = [
+    secret_permissions = length(var.secret_permissions) > 0 ? var.secret_permissions : [
       "Get",
+      "Delete",
+      "List",
+      "Set",
+    ]
+
+    storage_permissions = length(var.storage_permissions) > 0 ? var.storage_permissions : [
+      "Get",
+      "Delete",
+      "List",
+      "RegenerateKey",
+      "Set",
+      "Update",
     ]
   }
 }

--- a/modules/azure/key-vault/variables.tf
+++ b/modules/azure/key-vault/variables.tf
@@ -43,3 +43,33 @@ variable "enabled_for_disk_encryption" {
   type        = bool
   default     = true
 }
+
+variable "certificate_permissions" {
+  description = "A list of certificate permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "key_permissions" {
+  description = "A list of key permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "secret_permissions" {
+  description = "A list of secret permissions permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "storage_permissions" {
+  description = "A list of storage permissions for key vault to grant to object_id and application_id"
+  type        = list(string)
+  default     = []
+}
+
+variable "application_id" {
+  description = "The application ID to give to key vault when setting access policies"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Adds the ability to provide lists of access policy permissions for key vault.
The access policy permissions that can be overriden are:
- certificate_permissions
- key_permissions
- secret_permissions
- storage_permissions

This aligns with what is available through the AzureRM provider. When
the values are not provided, reasonable defaults are set. Those permissions
should be minimally required permissions for generic aspects. Application
specific deployments should override these permissions to align with principle
of least access.
Additionally you can now optionally set the `application_id` to further
assign access policies during key vault creation.