### PR TITLE
fix(external-dns): fix aad-pod-identity indexing

### DIFF
--- a/landing-zones/aks/applications/external-dns.tf
+++ b/landing-zones/aks/applications/external-dns.tf
@@ -13,7 +13,7 @@ module "public" {
 
   count = var.external_app ? 1 : 0
 
-  pod_identity = module.external_dns_pod_identity[0].identity_name
+  pod_identity = module.external_dns_pod_identity.identity_name
   dns_provider = "azure"
   domain_filters = [
     "${var.dns_zone_name}"


### PR DESCRIPTION
I'd like to get a second set of eyes on this, but I can't run a `plan` against the [applications module](https://github.com/liatrio/terraform-caf-azure/tree/main/landing-zones/aks/applications) without this change.