### PR TITLE
feat: add optional keyvault AAD group input

### DIFF
--- a/landing-zones/aks/core/.terraform.lock.hcl
+++ b/landing-zones/aks/core/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.5.0"
   constraints = "~> 3.5.0"
   hashes = [
-    "h1:vORxmkwrlOLM9LTL9DKj+CZQG58kGd+BBObgZT2P/RY=",
+    "h1:rrqTZIbikJEE2evZfzgh9+r0gsS3nytIYI9OXZpCfY4=",
     "zh:0d8ae6d6e87f44ed4a178be03d6466339b0bb578ab54c2677e365a8281b0bb7d",
     "zh:29d250d1a18d49652b28f234ecd17687b36c875dc47877a678e587d5d136b054",
     "zh:2e69ba373cf009e8a60b36d04f3dbc4638708d1bf88be9f96b3e52cbf8f47f31",
@@ -18,24 +18,5 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:c8f83b763b643893dcb6933a6bcee824cb514e06e7e5c5f5ac4ba187e66d7e22",
     "zh:dcdac07e7ea18464dea729717870c275de9453775243c231e1fb305cad0ee597",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/random" {
-  version = "3.1.3"
-  hashes = [
-    "h1:7+wnAXQM7IpNEAQ6WZXdO0ZfQW/ncQFXYJ5T2KaR+Z8=",
-    "zh:26e07aa32e403303fc212a4367b4d67188ac965c37a9812e07acee1470687a73",
-    "zh:27386f48e9c9d849fbb5a8828d461fde35e71f6b6c9fc235bc4ae8403eb9c92d",
-    "zh:5f4edda4c94240297bbd9b83618fd362348cadf6bf24ea65ea0e1844d7ccedc0",
-    "zh:646313a907126cd5e69f6a9fafe816e9154fccdc04541e06fed02bb3a8fa2d2e",
-    "zh:7349692932a5d462f8dee1500ab60401594dddb94e9aa6bf6c4c0bd53e91bbb8",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9034daba8d9b32b35930d168f363af04cecb153d5849a7e4a5966c97c5dc956e",
-    "zh:bb81dfca59ef5f949ef39f19ea4f4de25479907abc28cdaa36d12ecd7c0a9699",
-    "zh:bcf7806b99b4c248439ae02c8e21f77aff9fadbc019ce619b929eef09d1221bb",
-    "zh:d708e14d169e61f326535dd08eecd3811cd4942555a6f8efabc37dbff9c6fc61",
-    "zh:dc294e19a46e1cefb9e557a7b789c8dd8f319beca99b8c265181bc633dc434cc",
-    "zh:f9d758ee53c55dc016dd736427b6b0c3c8eb4d0dbbc785b6a3579b0ffedd9e42",
   ]
 }

--- a/landing-zones/aks/core/data.tf
+++ b/landing-zones/aks/core/data.tf
@@ -42,3 +42,9 @@ data "azurerm_virtual_network" "connectivity_vnet" {
   name                = "vnet-core-connectivity-apps-${var.location}"
   resource_group_name = var.connectivity_resource_group_name
 }
+
+data "azuread_group" "keyvault_contributors" {
+  count            = var.keyvault_group_name != "" ? 1 : 0
+  display_name     = var.keyvault_group_name
+  security_enabled = true
+}

--- a/landing-zones/aks/core/data.tf
+++ b/landing-zones/aks/core/data.tf
@@ -42,9 +42,3 @@ data "azurerm_virtual_network" "connectivity_vnet" {
   name                = "vnet-core-connectivity-apps-${var.location}"
   resource_group_name = var.connectivity_resource_group_name
 }
-
-data "azuread_group" "keyvault_contributors" {
-  count            = var.keyvault_group_name != "" ? 1 : 0
-  display_name     = var.keyvault_group_name
-  security_enabled = true
-}

--- a/landing-zones/aks/core/locals.tf
+++ b/landing-zones/aks/core/locals.tf
@@ -1,4 +1,4 @@
 locals {
   log_analytics_workspace_id = var.log_analytics_workspace_id == "" ? data.azurerm_log_analytics_workspace.management.id : var.log_analytics_workspace_id
-  keyvault_group_object_id   = var.keyvault_group_name == "" ? null : data.azuread_group.keyvault_contributors[0].object_id
+  keyvault_group_object_id   = var.keyvault_group_object_id == "" ? null : var.keyvault_group_object_id
 }

--- a/landing-zones/aks/core/locals.tf
+++ b/landing-zones/aks/core/locals.tf
@@ -1,3 +1,4 @@
 locals {
   log_analytics_workspace_id = var.log_analytics_workspace_id == "" ? data.azurerm_log_analytics_workspace.management.id : var.log_analytics_workspace_id
+  keyvault_group_object_id   = var.keyvault_group_name == "" ? null : data.azuread_group.keyvault_contributors[0].object_id
 }

--- a/landing-zones/aks/core/main.tf
+++ b/landing-zones/aks/core/main.tf
@@ -8,10 +8,6 @@ terraform {
         azurerm.management
       ]
     }
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.15.0"
-    }
   }
 }
 

--- a/landing-zones/aks/core/main.tf
+++ b/landing-zones/aks/core/main.tf
@@ -8,6 +8,10 @@ terraform {
         azurerm.management
       ]
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.15.0"
+    }
   }
 }
 
@@ -47,6 +51,7 @@ module "key_vault" {
   key_permissions                  = var.key_permissions
   secret_permissions               = var.secret_permissions
   storage_permissions              = var.storage_permissions
+  keyvault_group_object_id         = local.keyvault_group_object_id
 }
 
 module "key_gen" {

--- a/landing-zones/aks/core/variables.tf
+++ b/landing-zones/aks/core/variables.tf
@@ -163,3 +163,9 @@ variable "workload" {
   type        = string
   description = "The workload that we are supporting"
 }
+
+variable "keyvault_group_name" {
+  description = "OPTIONAL Name of AAD security group to which key vault access policies should be assigned. *MUST* include azuread provider config to use this variable"
+  type        = string
+  default     = ""
+}

--- a/landing-zones/aks/core/variables.tf
+++ b/landing-zones/aks/core/variables.tf
@@ -164,8 +164,8 @@ variable "workload" {
   description = "The workload that we are supporting"
 }
 
-variable "keyvault_group_name" {
-  description = "OPTIONAL Name of AAD security group to which key vault access policies should be assigned. *MUST* include azuread provider config to use this variable"
+variable "keyvault_group_object_id" {
+  description = "OPTIONAL Object ID of AAD security group to which key vault access policies should be assigned."
   type        = string
   default     = ""
 }

--- a/modules/azure/key-vault/locals.tf
+++ b/modules/azure/key-vault/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  keyvault_group_object_id = var.keyvault_group_object_id != null ? var.keyvault_group_object_id : data.azurerm_client_config.current.object_id
+}

--- a/modules/azure/key-vault/main.tf
+++ b/modules/azure/key-vault/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_key_vault" "key_vault" {
 
   access_policy {
     tenant_id      = data.azurerm_client_config.current.tenant_id
-    object_id      = data.azurerm_client_config.current.object_id
+    object_id      = local.keyvault_group_object_id
     application_id = var.application_id != null ? var.application_id : null
 
     certificate_permissions = length(var.certificate_permissions) > 0 ? var.certificate_permissions : [

--- a/modules/azure/key-vault/variables.tf
+++ b/modules/azure/key-vault/variables.tf
@@ -68,3 +68,9 @@ variable "application_id" {
   type        = string
   default     = null
 }
+
+variable "keyvault_group_object_id" {
+  description = "OPTIONAL Object ID of AAD security group to which key vault access policies should be assigned"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Adds optional root module input variable to landing-zones/aks/core to allow use of an AAD security group for keyvault access policies.